### PR TITLE
fix the name hashing overflow

### DIFF
--- a/src/filestore/util/name-hash.ts
+++ b/src/filestore/util/name-hash.ts
@@ -8,13 +8,13 @@ export function hash(name: string): number {
     let hash: number = 0;
 
     for(let i = 0; i < name.length; i++) {
-        hash = name.charCodeAt(i) + ((hash << 5) - hash);
-    }
+        hash = name.charCodeAt(i) + (hash << 5) - hash;
 
-    const overflow = hash - 2147483647;
+        const overflow = hash - 2147483647;
 
-    if(overflow > 0) {
-        hash = overflow - 2147483648 - 1;
+        if(overflow > 0) {
+            hash = overflow - 2147483648 - 1;
+        }
     }
 
     return hash;


### PR DESCRIPTION
The problem with the name hashing was that the number could overflow on a single character basis, but the overflow check was being done after all characters were checked. Here's a visual of the problem happening (left is filestore, right is client):

**Before**
![image](https://user-images.githubusercontent.com/6265839/112753238-118b1400-8fd7-11eb-9385-a299e66870f0.png)

**After**
![image](https://user-images.githubusercontent.com/6265839/112753245-194ab880-8fd7-11eb-96b0-c3a14c19892a.png)


For the two last `l`s in the string `b12_full`, the number was overflowing the MAX_INT from java, but it wasn't being caught until after the for loop finished running, which messed up the name hash.