### PR TITLE
refactor the fonts file a bit for better typings and getters

### DIFF
--- a/src/filestore/stores/font-store.ts
+++ b/src/filestore/stores/font-store.ts
@@ -2,13 +2,24 @@ import { Filestore } from '../filestore';
 import { SpritePack, SpriteStore, Sprite, toRgb } from './sprite-store';
 import { logger } from '@runejs/core';
 import { createCanvas, createImageData } from 'canvas';
+import { FileData } from '../file-data';
 
 
 /**
  * A list of game font file names.
  */
-export const fontNames = [
-    'p11_full', 'p12_full', 'b12_full', 'q8_full'
+export enum FontName {
+    p11_full = 'p11_full',
+    p12_full = 'p12_full',
+    b12_full = 'b12_full',
+    q8_full = 'q8_full'
+}
+
+export const fontNames: FontName[] = [
+    FontName.p11_full,
+    FontName.p12_full,
+    FontName.b12_full,
+    FontName.q8_full
 ];
 
 
@@ -151,9 +162,10 @@ export class FontStore {
     /**
      * A map of loaded game fonts by name.
      */
-    public readonly fonts: { [key: string]: Font } = {};
+    public readonly fonts: Map<FontName, Font>;
 
     public constructor(private readonly filestore: Filestore) {
+        this.fonts = new Map<FontName, Font>();
     }
 
     /**
@@ -161,10 +173,24 @@ export class FontStore {
      */
     public loadFonts(): FontStore {
         for(const fontName of fontNames) {
-            this.fonts[fontName] = new Font(fontName, this.filestore.spriteStore);
+            this.fonts.set(fontName, new Font(fontName, this.filestore.spriteStore));
         }
 
         return this;
     }
 
+    /**
+     * Fetches a font by its file name
+     */
+    public getFontByName(fontName: FontName): Font {
+        console.log(this.fonts.get(fontName));
+        return this.fonts.get(fontName);
+    }
+
+    /**
+     * Fetches a font by its ID
+     */
+    public getFontById(spriteId: number): Font {
+        return Array.from(this.fonts.values()).find(e => e.spritePack.packId === spriteId);
+    }
 }

--- a/src/filestore/stores/font-store.ts
+++ b/src/filestore/stores/font-store.ts
@@ -2,7 +2,6 @@ import { Filestore } from '../filestore';
 import { SpritePack, SpriteStore, Sprite, toRgb } from './sprite-store';
 import { logger } from '@runejs/core';
 import { createCanvas, createImageData } from 'canvas';
-import { FileData } from '../file-data';
 
 
 /**

--- a/src/filestore/stores/font-store.ts
+++ b/src/filestore/stores/font-store.ts
@@ -182,7 +182,6 @@ export class FontStore {
      * Fetches a font by its file name
      */
     public getFontByName(fontName: FontName): Font {
-        console.log(this.fonts.get(fontName));
         return this.fonts.get(fontName);
     }
 

--- a/src/filestore/stores/font-store.ts
+++ b/src/filestore/stores/font-store.ts
@@ -11,14 +11,20 @@ export enum FontName {
     p11_full = 'p11_full',
     p12_full = 'p12_full',
     b12_full = 'b12_full',
-    q8_full = 'q8_full'
+    q8_full = 'q8_full',
+
+    // Lunar alphabets only work with capital letters from A-Z
+    lunar_alphabet = 'lunar_alphabet',
+    lunar_alphabet_lrg = 'lunar_alphabet_lrg',
 }
 
 export const fontNames: FontName[] = [
     FontName.p11_full,
     FontName.p12_full,
     FontName.b12_full,
-    FontName.q8_full
+    FontName.q8_full,
+    FontName.lunar_alphabet,
+    FontName.lunar_alphabet_lrg
 ];
 
 


### PR DESCRIPTION
when working with text widgets, the only thing we get is the sprite ID for the font being used, so a getter by ID would be nice.
![image](https://user-images.githubusercontent.com/6265839/112754208-531dbe00-8fdb-11eb-8dbb-57dc73c833ed.png)

I refactored the font store a bit to support fetching by ID, as well as provide typings for the font file names